### PR TITLE
Add `defineCustomElements` call in exposed component. This is necessa…

### DIFF
--- a/src/App2Home.tsx
+++ b/src/App2Home.tsx
@@ -1,5 +1,8 @@
 import CounterButton from "shellApp/CounterButton";
 import { GroupuiButton } from "@group-ui/group-ui-react";
+import { defineCustomElements } from '@group-ui/group-ui-react/node_modules/@group-ui/group-ui/dist/components';
+
+void defineCustomElements();
 
 export default function App2Home() {
   return (


### PR DESCRIPTION
…ry so that app2's custom components are registered in the browser when app2 is integrated as a micro frontend in the shell app